### PR TITLE
Make the language switcher of the footer work again

### DIFF
--- a/src/js/misc/language-switcher.js
+++ b/src/js/misc/language-switcher.js
@@ -1,9 +1,11 @@
 // This code is for the language selector located
-// in the footer
-const el = document.querySelector('.js-language-switcher');
-if (el) {
-  el.addEventListener('change', ({ target }) => {
-    window.logEvent('Change Language', 'Clicks to change language', target.selectedOptions[0].getAttribute('data-lang'));
-    window.location = target.value;
+// in the header and footer
+const els = document.querySelectorAll('.js-language-switcher');
+if (els.length) {
+  els.forEach((el) => {
+    el.addEventListener('change', ({ target }) => {
+      window.logEvent('Change Language', 'Clicks to change language', target.selectedOptions[0].getAttribute('data-lang'));
+      window.location = target.value;
+    });
   });
 }


### PR DESCRIPTION
The language switcher wouldn't work anymore because another one has been added to the header (visible only on mobile) and the code would only search for one.

@andresgnlez The styles of the language switcher needs some adjusting in the header.

[Pivotal task](https://www.pivotaltracker.com/story/show/156153284)